### PR TITLE
Add sort methods to let Kodi handle sorting

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.cbc"
        name="Canadian Broadcasting Corp (CBC)"
-       version="4.0.6"
+       version="4.0.7~dev1"
        provider-name="micahg,t1m">
   <requires>
     <import addon="xbmc.python" version="2.26.0"/>

--- a/default.py
+++ b/default.py
@@ -117,6 +117,8 @@ def liveProgramsMenu():
         url = sys.argv[0] + "?" + urlencode(values)
         xbmcplugin.addDirectoryItem(addon_handle, url, item,False)
 
+    xbmcplugin.addSortMethod(addon_handle, xbmcplugin.SORT_METHOD_TITLE_IGNORE_THE)
+    xbmcplugin.addSortMethod(addon_handle, xbmcplugin.SORT_METHOD_TITLE)
     xbmcplugin.endOfDirectory(addon_handle)
 
 
@@ -140,6 +142,8 @@ def liveChannelsMenu():
         url = sys.argv[0] + "?" + urlencode(values)
         xbmcplugin.addDirectoryItem(addon_handle, url, item, False)
 
+    xbmcplugin.addSortMethod(addon_handle, xbmcplugin.SORT_METHOD_TITLE_IGNORE_THE)
+    xbmcplugin.addSortMethod(addon_handle, xbmcplugin.SORT_METHOD_TITLE)
     xbmcplugin.endOfDirectory(addon_handle)
 
 
@@ -198,7 +202,9 @@ def showsMenu(values):
 
         plugin_url = sys.argv[0] + "?" + urlencode(values)
         xbmcplugin.addDirectoryItem(addon_handle, plugin_url, item, not isVideo)
-
+        
+    xbmcplugin.addSortMethod(addon_handle, xbmcplugin.SORT_METHOD_TITLE_IGNORE_THE)
+    xbmcplugin.addSortMethod(addon_handle, xbmcplugin.SORT_METHOD_TITLE)
     xbmcplugin.endOfDirectory(addon_handle)
 
 


### PR DESCRIPTION
By adding these two sort methods, Kodi now will select between either one based on "Ignore article sort" option in the Media settings. 
