### PR TITLE
Added Category label to settings.xml

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <settings>
-   <setting id="username"  type="text" label="30007"/>
-   <setting id="password"  type="text" label="30008" option="hidden"/>
-   <setting id="ffmpeg"    type="bool" label="30013" default="true"/>
-   <setting id="logout" option="close" label="30009" type="action" action="RunScript(plugin.video.cbc, logout)"/>
+   <category label="Settings">
+      <setting id="username"  type="text" label="30007"/>
+      <setting id="password"  type="text" label="30008" option="hidden"/>
+      <setting id="ffmpeg"    type="bool" label="30013" default="true"/>
+      <setting id="logout" option="close" label="30009" type="action" action="RunScript(plugin.video.cbc, logout)"/>
+   </category>
 </settings>


### PR DESCRIPTION
Minor cosmetic fix: added category in setting.xml to display settings label instead of empty rectangle on mouse over in settings menu

Before:

![01 Before](https://user-images.githubusercontent.com/49594656/119241408-aca5f300-bb1b-11eb-8a7a-166df03205a6.png)

After:

![02 After](https://user-images.githubusercontent.com/49594656/119241415-b29bd400-bb1b-11eb-82e1-53bfe5d695d7.png)
