### PR TITLE
Updated Gem v2 API to return episodes for selected season

### DIFF
--- a/resources/lib/gemv2.py
+++ b/resources/lib/gemv2.py
@@ -2,7 +2,7 @@
 import json
 
 import requests
-
+import re
 from resources.lib.cbc import CBC
 from resources.lib.utils import loadAuthorization, log
 
@@ -68,6 +68,12 @@ class GemV2:
             return content['items']['results']
         
         if 'requestedType' in jsObj and jsObj['requestedType'].lower() == 'season':
+            # find season from url
+            season_no = re.search("s(\d+)($|\?)", url.lower())
+            if season_no is not None:
+                for lineup in content['lineups']:
+                    if lineup['seasonNumber'] == int(season_no.group(1)):
+                        return lineup['items']
             return content['lineups'][0]['items']
         if 'lineups' in content:
             return content['lineups']


### PR DESCRIPTION
Thanks for building this addon.  Despite what I see on the Kodi forums, videos are still working for me in the addon (watching CBC content anyways).

I did notice that the new gemv2 was not showing the proper episodes for each season and always showed the episodes for the first available season no matter which season was selected.  It appears that even when returning a season request, the lineups for all available seasons are returning now.  Here is a solution that is working for me at the moment.